### PR TITLE
Fixed QuantEcon julia link in readme and typo in Week 1 slides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Office hours: By appointment, please email
 
 ### Assessment
 
-Grades will be based on assignments (75%) and a final exam (25%).
+Grades will be based on assignments (70%) and a final exam (30%).
 
 Assignments will be posted to the GitHub repository.
 Submit your work via the Courseworks site.
@@ -46,7 +46,7 @@ Economics](https://github.com/jesusfv/Comparison-Programming-Languages-Economics
 the [Julia language](http://www.julialang.org).
 Julia's advantages are that it is open source and typically faster than Matlab.
 To get started doing economics in Julia, see Perla, Sargent, and Stachurski's
-"[Lectures in Quantitative Economics](https://lectures.quantecon.org/jl/)."
+"[Lectures in Quantitative Economics](https://julia.quantecon.org/intro.html)."
 You may submit Julia or Matlab code as homework solutions.
 Please confer with me before submitting code written in other languages.
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Office hours: By appointment, please email
 
 ### Assessment
 
-Grades will be based on assignments (70%) and a final exam (30%).
+Grades will be based on assignments (75%) and a final exam (25%).
 
 Assignments will be posted to the GitHub repository.
 Submit your work via the Courseworks site.

--- a/slides/week01_armington/slides.tex
+++ b/slides/week01_armington/slides.tex
@@ -259,7 +259,7 @@ We will discuss
 \end{itemize}
 \end{frame}
 % -----------------------------------------
-\begin{frame}{Armington model with CES prefences}
+\begin{frame}{Armington model with CES preferences}
 \begin{itemize}
 	\item Each country has its own ``signature'' good (others have zero productivity in this good; maximal absolute advantage)
 	\item Bilateral trade costs of the \href{https://tradediversion.net/2019/10/28/whats-an-iceberg-commuting-cost/}{iceberg} form $\tau_{ij}$

--- a/slides/week01_armington/slides.tex
+++ b/slides/week01_armington/slides.tex
@@ -45,7 +45,7 @@ and the Trade and Spatial Workshop (select Fridays, 1:30--5:00) %in IAB 1101
 \begin{frame}{Assessment}
 My goal is to introduce some concepts and tools in international trade and economic geography so you can tackle relevant research questions
 \begin{itemize}
-\item Grades based on assignments (70\%) and a final exam (30\%)
+\item Grades based on assignments (75\%) and a final exam (25\%)
 \item Three types of assignments
 \begin{itemize}
 \item Economics: Derive a theoretical result or survey an empirical literature.


### PR DESCRIPTION
The link in the `readme` to the QuantEcon Julia page has changed (old link broken), updated grading split, and fixed small typo in the Week 1 slides.